### PR TITLE
Use multiprocessing to eliminate audio lag

### DIFF
--- a/app/meter.py
+++ b/app/meter.py
@@ -1,5 +1,5 @@
 """The meter module provides the Meter class."""
-import thread
+import multiprocessing as mp
 import time
 import Tkinter
 from Tkinter import Canvas
@@ -104,7 +104,7 @@ class Meter(Canvas):
     def start(self):
         """Start the meter."""
         self._is_playing = True
-        thread.start_new_thread(self._run, ())
+        mp.Process(target=self._run).start()
 
     def reset(self):
         """Reset the meter."""

--- a/app/player_madao.py
+++ b/app/player_madao.py
@@ -3,7 +3,7 @@
 This implementation of Player uses python wrappers for libmad and libao,
 which provide interfaces to audio files and audio devices.
 """
-import thread
+import multiprocessing as mp
 import time
 import ao
 import mad
@@ -67,7 +67,7 @@ class Player(object):
 
         self._is_playing = True
         self._callback = callback
-        thread.start_new_thread(self._play_internal, ())
+        mp.Process(target=self._play_internal).start()
 
     def stop(self):
         """Stop the audio stream."""

--- a/app/player_vlc.py
+++ b/app/player_vlc.py
@@ -4,10 +4,10 @@ This implementation of Player uses VLC in a separate process, although
 it also uses libmad to retreive the length of the file. This implementation
 seems to work, although it prints cryptic messages from time to time.
 """
+import multiprocessing as mp
 import os
 import signal
 import subprocess
-import thread
 import time
 
 import mad
@@ -68,7 +68,7 @@ class Player(object):
         self._pid = subprocess.Popen(self._command).pid
         self._is_playing = True
         self._callback = callback
-        thread.start_new_thread(self._play_internal, ())
+        mp.Process(target=self._play_internal).start()
 
     def stop(self):
         """Stop the audio stream."""

--- a/app/za_studio.py
+++ b/app/za_studio.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """The Studio module provides a GUI for the digital library."""
-import thread
+import multiprocessing as mp
 import Tkinter
 from Tkinter import Frame, Label, BooleanVar, Checkbutton, Entry, Button
 import database
@@ -124,11 +124,8 @@ class Studio(Frame):
             print "Found %d results." % len(self._search_results)
 
     def search(self, *args):
-        """Search the digital library.
-
-        :param args
-        """
-        thread.start_new_thread(self._search_internal, ())
+        """Search the digital library."""
+        mp.Process(target=self._search_internal).start()
 
     def select_cart(self, index):
         """Select a cart from the search results.

--- a/test/test_meter.py
+++ b/test/test_meter.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 """Test suite for the meter module."""
+import multiprocessing as mp
 import sys
 import time
-import thread
 from Tkinter import Frame, Canvas
 
 sys.path.insert(0, 'app')
@@ -33,7 +33,7 @@ class Test(Frame):
         Canvas(self.master, width=900, height=100, bg='#00F').grid(row=2, column=0, columnspan=NUM_COLS)
 
         self._meter.start()
-        thread.start_new_thread(self._run, ())
+        mp.Process(target=self._run).start()
 
         self.master.title("Testing Program")
         self.master.mainloop()


### PR DESCRIPTION
One problem I never got rid of when I renovated ZAutomate was the audio lag which happens intermittently or especially whenever the user performs a large search. I still hear the lag happen occasionally even during automation. What I know now that I didn't know then is that multithreading in Python isn't very effective because of the GIL, so Python provides the multiprocessing package to enable multi-threading but with separate processes instead of threads, which circumvents the GIL.

It's a simple fix but I can't test it myself as I don't have access to the studio anymore. @garrettdunc I see you're listed as the current computer engineer, if you could test my fixes in the studio when you get a chance and let me know if it works then we can get these fixes merged into the master branch.